### PR TITLE
Add genome-wide CNV plotting feature

### DIFF
--- a/spectre/analysis/analysis.py
+++ b/spectre/analysis/analysis.py
@@ -16,6 +16,7 @@ from spectre.analysis.coverage_stats import CoverageStatistics
 from spectre.classes.loh_candidate import MergeCNVLoH
 from spectre.plots.plot import CNVPlot
 from spectre.plots.plot import CoveragePlot
+from spectre.plots.plot import GenomeCNVPlot
 from spectre.util.cnv_id import CNV_ID
 from spectre.util.metadata.metadataCollector import FastaRef
 
@@ -773,6 +774,30 @@ class CNVAnalysis(object):
                                               {"pos": chr_cov_data.positions,
                                                "cov": chr_cov_data.normalized_cov_ploidy},
                                               self.cnv_calls_list[each_chromosome], [lower_bound, upper_bound])
+
+    def cnv_plot_genome(self, methode=""):
+        coverage_per_chr = {}
+        cnv_per_chr = {}
+        chr_lengths = {}
+        for each_chromosome in self.coverage_analysis.keys():
+            chr_cov_data = self.coverage_analysis[each_chromosome]["cov_data"]
+            coverage_per_chr[each_chromosome] = {
+                "pos": chr_cov_data.positions,
+                "cov": chr_cov_data.normalized_cov_ploidy,
+            }
+            cnv_per_chr[each_chromosome] = self.cnv_calls_list[each_chromosome]
+            if each_chromosome in self.genome_info["chr_lengths"]:
+                chr_lengths[each_chromosome] = self.genome_info["chr_lengths"][each_chromosome]
+            else:
+                chr_lengths[each_chromosome] = chr_cov_data.positions[-1] if len(chr_cov_data.positions) > 0 else 0
+
+        new_plot_device = GenomeCNVPlot()
+        new_plot_device.output_directory = self.output_directory
+        new_plot_device.file_prefix = methode + self.sample_id
+        bounds = [self.lower_2n_threshold, self.upper_2n_threshold]
+        new_plot_device.plot_genome(coverage_per_chr, cnv_per_chr, chr_lengths,
+                                    baseline=self.spectre_args.ploidy,
+                                    bounds=bounds)
 
     def get_cnv_metrics(self, refined_cnvs: bool = False):
         """

--- a/spectre/plots/plot.py
+++ b/spectre/plots/plot.py
@@ -84,3 +84,113 @@ class CNVPlot:
         self.figure.savefig(f'{self.output_directory}/img/{self.file_prefix}_plot_cnv_{current_chromosome}.png', dpi=300)
         self.logger.info(f'Plot saved: img/{self.file_prefix}_plot_cnv_{current_chromosome}.png')
         self.figure.clf()
+
+
+class GenomeCNVPlot:
+    """Plot coverage and CNV calls for the whole genome in one figure."""
+
+    def __init__(self, as_dev: bool = False):
+        logging.getLogger('matplotlib.font_manager').disabled = True
+        self.logger = logger.setup_log(__name__, as_dev)
+        self.figure = plot_engine.figure(figsize=(16, 6))
+        gs = gridspec.GridSpec(2, 1, height_ratios=[5, 1])
+        self.main_plot = plot_engine.subplot(gs[0])
+        self.candidates_plot = plot_engine.subplot(gs[1])
+        self.candidates_plot.axes.get_yaxis().set_visible(False)
+        self.coverage_color = "#67a9cf"
+        self.cnv_color = {"DUP": "#d73027", "DEL": "#1a9850"}
+        self.axis_ylim = {"bottom": 0, "top": 6}
+        self.file_prefix = "test"
+        self.output_directory = "./"
+
+    def plot_genome(self, coverage_per_chr: dict, cnv_per_chr: dict, chr_lengths: dict,
+                    baseline: float = 2.0, bounds: list | None = None):
+        """Create genome wide CNV plot.
+
+        Parameters
+        ----------
+        coverage_per_chr : dict
+            Dictionary with chromosome -> {"pos": [...], "cov": [...]}.
+        cnv_per_chr : dict
+            Dictionary with chromosome -> list[CNVCandidate].
+        chr_lengths : dict
+            Dictionary with chromosome lengths.
+        """
+
+        if len(coverage_per_chr) == 0:
+            self.logger.error("No coverage provided for genome plot")
+            return
+
+        chromosomes = list(coverage_per_chr.keys())
+
+        all_pos = []
+        all_cov = []
+        xticks = []
+        labels = []
+        boundaries = []
+        scale_ticks = []
+        scale_labels = []
+
+        offset = 0
+        for chrom in chromosomes:
+            pos = np.array(coverage_per_chr[chrom]["pos"]) + offset
+            cov = np.array(coverage_per_chr[chrom]["cov"])
+            all_pos.append(pos)
+            all_cov.append(cov)
+            length = chr_lengths.get(chrom, pos[-1] if len(pos) > 0 else 0)
+            xticks.append(offset + length / 2)
+            labels.append(chrom)
+            offset += length
+            boundaries.append(offset)
+            tick_val = 1
+            while tick_val < length:
+                scale_ticks.append(offset - length + tick_val)
+                scale_labels.append(f"{tick_val}")
+                tick_val *= 10
+
+        all_pos = np.concatenate(all_pos)
+        all_cov = np.concatenate(all_cov)
+
+        # plot coverage
+        self.main_plot.plot(all_pos, all_cov, color=self.coverage_color, linewidth='0.5')
+        self.main_plot.axes.set_ylim(bottom=self.axis_ylim["bottom"], top=self.axis_ylim["top"])
+
+        # baseline and bounds
+        genome_end = boundaries[-1]
+        self.main_plot.plot(np.array([0, genome_end]), np.array([baseline, baseline]),
+                            linewidth='1', color="#000000")
+        if bounds is not None and len(bounds) == 2:
+            upperb, lowerb = bounds[1], bounds[0]
+            self.main_plot.plot(np.array([0, genome_end]), np.array([lowerb, lowerb]),
+                                linewidth='1', color="#1a9850")
+            self.main_plot.plot(np.array([0, genome_end]), np.array([upperb, upperb]),
+                                linewidth='1', color="#d73027")
+
+        # plot CNV segments
+        offset = 0
+        for chrom in chromosomes:
+            if chrom in cnv_per_chr:
+                for cnv in cnv_per_chr[chrom]:
+                    start = cnv.start + offset
+                    end = cnv.end + offset
+                    cnv_color = self.cnv_color.get(cnv.type, "#000000")
+                    self.candidates_plot.plot(np.array([start, end]), np.array([0, 0]),
+                                              linewidth='5', color=cnv_color)
+            offset += chr_lengths.get(chrom, 0)
+
+        # draw chromosome boundaries
+        for boundary in boundaries[:-1]:
+            self.main_plot.axvline(boundary, color="grey", linewidth=0.5)
+            self.candidates_plot.axvline(boundary, color="grey", linewidth=0.5)
+
+        self.main_plot.set_xticks(xticks)
+        self.main_plot.set_xticklabels(labels, rotation=90, fontsize=6)
+        self.candidates_plot.set_xticks(scale_ticks)
+        self.candidates_plot.set_xticklabels(scale_labels, rotation=90, fontsize=6)
+
+        self.figure.tight_layout()
+        output_path = f'{self.output_directory}/img/{self.file_prefix}_plot_cnv_genome.png'
+        self.figure.savefig(output_path, dpi=300)
+        self.logger.info(f'Plot saved: {output_path}')
+        self.figure.clf()
+

--- a/spectre/spectreCNV.py
+++ b/spectre/spectreCNV.py
@@ -129,6 +129,7 @@ class SpectreCNV:
         self.cnv_analysis.cnv_result_vcf()
         self.logger.info("Result plot in progress")
         self.cnv_analysis.cnv_plot()
+        self.cnv_analysis.cnv_plot_genome()
         # End
         self.logger.info(f"Output dir: {self.spectre_args.out_dir}")
         self.logger.info(f"Done with sample {self.sample_id}")


### PR DESCRIPTION
## Summary
- implement `GenomeCNVPlot` for whole genome coverage & CNVs
- expose a new `cnv_plot_genome` routine in `analysis.py`
- call genome-wide plotting from `SpectreCNV`
- improve global plot with wider figure, baseline and thresholds, per-chromosome log scale labels

## Testing
- `python -m compileall -q spectre`


------
https://chatgpt.com/codex/tasks/task_e_6847ab5bd7248327877882fa1d5575df